### PR TITLE
Implement shared modules and integrate dual simulation

### DIFF
--- a/src/core/dualMeet.ts
+++ b/src/core/dualMeet.ts
@@ -1,1 +1,112 @@
 // Dual meet simulation logic
+import { WEIGHT_CLASSES } from "../data/weights";
+import { simulateMatch, WinMethod, Wrestler } from "./match";
+
+export interface Team {
+  name: string;
+  wrestlers: Wrestler[];
+}
+
+export interface BoutResult {
+  weightClass: number;
+  a?: Wrestler;
+  b?: Wrestler;
+  winnerSide: "A" | "B" | "none";
+  method: WinMethod | "forfeit";
+  summary: string;
+}
+
+export interface DualResult {
+  log: string;
+  scoreA: number;
+  scoreB: number;
+  bouts: BoutResult[];
+}
+
+export function teamPointsForMethod(method: WinMethod | "forfeit"): number {
+  switch (method) {
+    case "pin":
+    case "forfeit":
+      return 6;
+    case "tech fall":
+      return 5;
+    case "major":
+      return 4;
+    case "decision":
+    default:
+      return 3;
+  }
+}
+
+interface DualOptions {
+  weightClasses?: number[];
+  matchSimulator?: typeof simulateMatch;
+}
+
+export function simulateDual(teamA: Team, teamB: Team, options: DualOptions = {}): DualResult {
+  const weightClasses = options.weightClasses || WEIGHT_CLASSES;
+  const matchSimulator = options.matchSimulator || simulateMatch;
+
+  let scoreA = 0;
+  let scoreB = 0;
+  const lines: string[] = [];
+  const bouts: BoutResult[] = [];
+
+  lines.push(`${teamA.name} vs ${teamB.name}`);
+  lines.push(`--------------------------------`);
+
+  for (const wc of weightClasses) {
+    const aW = teamA.wrestlers.find((w) => w.weightClass === wc);
+    const bW = teamB.wrestlers.find((w) => w.weightClass === wc);
+
+    if (!aW && !bW) continue;
+
+    if (aW && !bW) {
+      scoreA += 6;
+      lines.push(`${wc}: ${teamA.name} wins by forfeit (6-0) - ${aW.name}`);
+      bouts.push({
+        weightClass: wc,
+        a: aW,
+        winnerSide: "A",
+        method: "forfeit",
+        summary: `${aW.name} wins by forfeit`,
+      });
+      continue;
+    }
+
+    if (!aW && bW) {
+      scoreB += 6;
+      lines.push(`${wc}: ${teamB.name} wins by forfeit (6-0) - ${bW.name}`);
+      bouts.push({
+        weightClass: wc,
+        b: bW,
+        winnerSide: "B",
+        method: "forfeit",
+        summary: `${bW.name} wins by forfeit`,
+      });
+      continue;
+    }
+
+    const { winner, method, summary } = matchSimulator(aW!, bW!);
+    const pts = teamPointsForMethod(method);
+
+    if (winner === aW) scoreA += pts;
+    else scoreB += pts;
+
+    const teamStr = winner === aW ? teamA.name : teamB.name;
+    lines.push(`${wc}: ${summary} (${teamStr} +${pts})`);
+    bouts.push({
+      weightClass: wc,
+      a: aW!,
+      b: bW!,
+      winnerSide: winner === aW ? "A" : "B",
+      method,
+      summary,
+    });
+  }
+
+  lines.push(`--------------------------------`);
+  lines.push(`Final Team Score: ${teamA.name} ${scoreA} - ${scoreB} ${teamB.name}`);
+
+  return { log: lines.join("\n"), scoreA, scoreB, bouts };
+}

--- a/src/core/match.ts
+++ b/src/core/match.ts
@@ -1,18 +1,97 @@
 // Match simulation logic
+export type WinMethod = "decision" | "major" | "tech fall" | "pin";
+
 export interface Wrestler {
+  id: string;
   name: string;
   weight: number;
+  weightClass: number;
+  neutral: number;
   top: number;
   bottom: number;
-  neutral: number;
   strength: number;
   conditioning: number;
   technique: number;
+  morale?: number;
+  health?: number;
+  fatigue?: number;
+  classYear?: "FR" | "SO" | "JR" | "SR";
+  potential?: number;
+  injury?: { type: "minor" | "moderate" | "major"; days: number };
+  form?: number;
+  formDays?: number;
 }
 
-export function simulateMatch(a: Wrestler, b: Wrestler): string {
-  const aSkill = a.neutral + a.top + a.bottom + a.technique + a.strength * 0.5;
-  const bSkill = b.neutral + b.top + b.bottom + b.technique + b.strength * 0.5;
-  const result = aSkill + Math.random() * 10 > bSkill + Math.random() * 10 ? a.name : b.name;
-  return `${result} wins!`;
+export function simulateMatch(
+  a: Wrestler,
+  b: Wrestler
+): { winner: Wrestler; loser: Wrestler; method: WinMethod; summary: string } {
+  const aFatigue = a.fatigue || 20;
+  const bFatigue = b.fatigue || 20;
+  const aHealth = a.health || 100;
+  const bHealth = b.health || 100;
+  const aMorale = a.morale || 70;
+  const bMorale = b.morale || 70;
+
+  const aInjuryPenalty =
+    a.injury && a.injury.days > 0
+      ? a.injury.type === "major"
+        ? 0.6
+        : a.injury.type === "moderate"
+        ? 0.8
+        : 0.9
+      : 1;
+  const bInjuryPenalty =
+    b.injury && b.injury.days > 0
+      ? b.injury.type === "major"
+        ? 0.6
+        : b.injury.type === "moderate"
+        ? 0.8
+        : 0.9
+      : 1;
+
+  const aStyle = a.neutral * 0.3 + a.top * 0.25 + a.bottom * 0.2 + a.technique * 0.25;
+  const bStyle = b.neutral * 0.3 + b.top * 0.25 + b.bottom * 0.2 + b.technique * 0.25;
+
+  const aBase =
+    (overallScore(a) + aStyle * 0.05 + (aMorale - 70) * 0.1 + (aHealth - 90) * 0.05 - aFatigue * 0.1 + (a.form || 0) * 1.2) *
+    aInjuryPenalty;
+  const bBase =
+    (overallScore(b) + bStyle * 0.05 + (bMorale - 70) * 0.1 + (bHealth - 90) * 0.05 - bFatigue * 0.1 + (b.form || 0) * 1.2) *
+    bInjuryPenalty;
+
+  const strategyMod = 1; // neutral baseline
+
+  const aScore = aBase * strategyMod + Math.random() * 10;
+  const bScore = bBase + Math.random() * 10;
+
+  const winner = aScore >= bScore ? a : b;
+  const loser = winner === a ? b : a;
+
+  const diff = Math.abs(aScore - bScore);
+  let method: WinMethod = "decision";
+
+  if (diff > 15) method = "pin";
+  else if (diff > 10) method = "tech fall";
+  else if (diff > 6) method = "major";
+
+  const summary = `${winner.name} defeats ${loser.name} by ${method}.`;
+
+  winner.form = Math.min(2, (winner.form || 0) + 1);
+  winner.formDays = 5;
+  loser.form = Math.max(-2, (loser.form || 0) - 1);
+  loser.formDays = 5;
+
+  return { winner, loser, method, summary };
+}
+
+function overallScore(w: Wrestler): number {
+  return (
+    w.neutral * 0.25 +
+    w.top * 0.2 +
+    w.bottom * 0.2 +
+    w.technique * 0.2 +
+    w.strength * 0.1 +
+    w.conditioning * 0.05
+  );
 }

--- a/src/core/rng.ts
+++ b/src/core/rng.ts
@@ -1,1 +1,12 @@
-// Random number generator
+// Random number generator utilities
+export function createId(): string {
+  return crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2);
+}
+
+export function pickRandom<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+export function randomDelta(range: number): number {
+  return Math.floor((Math.random() * 2 - 1) * range);
+}

--- a/src/data/weights.ts
+++ b/src/data/weights.ts
@@ -1,1 +1,2 @@
 // Weight class data
+export const WEIGHT_CLASSES = [125, 133, 141, 149, 157, 165, 174, 184, 197, 285];

--- a/src/store/storage.ts
+++ b/src/store/storage.ts
@@ -1,1 +1,62 @@
 // Save/load functionality
+export interface SavedState<
+  TWrestler = unknown,
+  TProspect = unknown,
+  TDual = unknown,
+  TLeague = unknown,
+  TLive = unknown
+> {
+  roster: TWrestler[];
+  teamName?: string;
+  dayOfWeek?: number;
+  seasonWeek?: number;
+  seasonWins?: number;
+  seasonLosses?: number;
+  lineupSelections?: Record<number, string | null>;
+  recruits?: TProspect[];
+  shortlist?: TProspect[];
+  programId?: string;
+  budget?: number;
+  nilBudget?: number;
+  committedThisSeason?: number;
+  weeklySummaries?: string[];
+  league?: TLeague[];
+  postseasonLog?: string;
+  postseasonBracket?: { semifinal1?: TDual; semifinal2?: TDual; final?: TDual };
+  signedRecruits?: TProspect[];
+  prestige?: number;
+  postseasonPlayed?: boolean;
+  liveDualState?: TLive;
+}
+
+export function saveState(key: string, state: SavedState, onMessage?: (msg: string) => void): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(state));
+    onMessage?.("Roster saved.");
+  } catch (err) {
+    console.error(err);
+    onMessage?.("Error saving roster.");
+  }
+}
+
+export function loadState<T extends SavedState>(
+  key: string,
+  legacyKey?: string,
+  onMessage?: (msg: string) => void
+): T | null {
+  let raw = localStorage.getItem(key);
+  if (!raw && legacyKey) {
+    raw = localStorage.getItem(legacyKey);
+  }
+  if (!raw) {
+    onMessage?.("No saved roster found.");
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    console.error(err);
+    onMessage?.("Error loading roster.");
+    return null;
+  }
+}

--- a/src/ui/logger.ts
+++ b/src/ui/logger.ts
@@ -1,1 +1,5 @@
 // Logger for UI output
+export function logToElement(target: HTMLElement | null | undefined, message: string): void {
+  if (!target) return;
+  target.textContent = message;
+}

--- a/src/ui/rosterUI.ts
+++ b/src/ui/rosterUI.ts
@@ -1,1 +1,111 @@
 // Roster UI interactions
+import { WEIGHT_CLASSES } from "../data/weights";
+
+export interface WrestlerCard {
+  id: string;
+  name: string;
+  weightClass: number;
+  injury?: { type: "minor" | "moderate" | "major"; days: number };
+  form?: number;
+  fatigue?: number;
+}
+
+export interface RosterCardOptions<T extends WrestlerCard> {
+  weightClass: number;
+  wrestlers: T[];
+  selectedId: string | null | undefined;
+  onSelect: (value: string | null) => void;
+  overallScore: (w: T) => number;
+}
+
+export function renderRosterList<T extends WrestlerCard>(
+  container: HTMLElement | null,
+  wrestlers: T[],
+  overallScore: (w: T) => number
+): void {
+  if (!container) return;
+  container.innerHTML = "";
+  wrestlers.forEach((w) => {
+    const li = document.createElement("li");
+    const injury = w.injury && w.injury.days > 0 ? ` | ${w.injury.type} (${w.injury.days}d)` : "";
+    const formBadge = w.form && w.form !== 0 ? ` | Form ${w.form > 0 ? "+" : ""}${w.form}` : "";
+    li.textContent = `${w.name} (${w.weightClass}) | OVR ${overallScore(w).toFixed(1)}${injury}${formBadge}`;
+    container.appendChild(li);
+  });
+}
+
+export function buildLineupCard<T extends WrestlerCard>(options: RosterCardOptions<T>): HTMLDivElement {
+  const { weightClass, wrestlers, selectedId, onSelect, overallScore } = options;
+  const card = document.createElement("div");
+  card.className = "lineup-card";
+  const selected = wrestlers.find((c) => c.id === selectedId) || wrestlers[0];
+  const name = selected ? selected.name : "Open";
+  const ovr = selected ? overallScore(selected).toFixed(1) : "--";
+  const badges: string[] = [];
+  if (selected && selected.injury && selected.injury.days > 0) badges.push(`${selected.injury.type} (${selected.injury.days}d)`);
+  if (selected && selected.form) badges.push(`Form ${selected.form > 0 ? "+" : ""}${selected.form}`);
+  if (selected && selected.fatigue && selected.fatigue > 70) badges.push(`Fatigue ${selected.fatigue}`);
+
+  const select = document.createElement("select");
+  const openOpt = document.createElement("option");
+  openOpt.value = "";
+  openOpt.textContent = "Open Slot";
+  select.appendChild(openOpt);
+
+  wrestlers
+    .sort((a, b) => overallScore(b) - overallScore(a))
+    .forEach((c) => {
+      const opt = document.createElement("option");
+      opt.value = c.id;
+      opt.textContent = `${c.name} (OVR ${overallScore(c).toFixed(1)})`;
+      select.appendChild(opt);
+    });
+
+  select.value = selectedId || "";
+  select.addEventListener("change", (e) => {
+    const value = (e.target as HTMLSelectElement).value;
+    onSelect(value || null);
+  });
+
+  card.innerHTML = `
+    <h3>${weightClass} lbs</h3>
+    <p class="name">${name}</p>
+    <p class="meta">${selected ? `OVR ${ovr}` : "No wrestler"}</p>
+  `;
+
+  if (badges.length) {
+    const badgeWrap = document.createElement("div");
+    badgeWrap.className = "badges";
+    for (const b of badges) {
+      const span = document.createElement("span");
+      span.className = "badge";
+      span.textContent = b;
+      badgeWrap.appendChild(span);
+    }
+    card.appendChild(badgeWrap);
+  }
+
+  const selectWrap = document.createElement("div");
+  selectWrap.className = "select";
+  selectWrap.appendChild(select);
+  card.appendChild(selectWrap);
+
+  return card;
+}
+
+export function ensureLineupSelections(
+  lineupSelections: Record<number, string | null>,
+  roster: WrestlerCard[],
+  weightClasses: number[] = WEIGHT_CLASSES
+): void {
+  for (const wc of weightClasses) {
+    const selectedId = lineupSelections[wc];
+    const exists = selectedId ? roster.some((w) => w.id === selectedId) : false;
+    if (!exists) {
+      const best = roster
+        .filter((w) => w.weightClass === wc)
+        .sort((a, b) => (a.id > b.id ? 1 : -1))[0];
+      lineupSelections[wc] = best ? best.id : null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement dual meet simulation, RNG helpers, weight class data, UI logging, and roster rendering utilities
- align match simulation exports and storage helpers for reuse across the app
- integrate new modules into the main game loop and simplify save/load handling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c30ba7d5c832582803b3f09001122)