### PR TITLE
Add dedicated competition results page

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
       <button class="nav-btn" data-view="dashboard">Dashboard</button>
       <button class="nav-btn" data-view="training">Training</button>
       <button class="nav-btn" data-view="duals">Duals</button>
+      <button class="nav-btn" data-view="results">Results</button>
     </nav>
 
     <section id="program-select" class="card overlay fullscreen">
@@ -71,6 +72,10 @@
             <button class="tile-card" data-target="dashboard">
               <div class="tile-title">State Ranking</div>
               <div class="tile-body" id="tile-state-rank">--</div>
+            </button>
+            <button class="tile-card" data-target="results">
+              <div class="tile-title">Competition Results</div>
+              <div class="tile-body">Duals & tournaments</div>
             </button>
             <button class="tile-card" data-target="duals">
               <div class="tile-title">Duals</div>
@@ -199,9 +204,11 @@
               <h3>Upcoming</h3>
               <ul id="schedule-list" class="list"></ul>
             </div>
-            <div>
-              <h3>Results</h3>
-              <ul id="results-list" class="list"></ul>
+            <div class="results-callout" data-target="results">
+              <p class="eyebrow">Competition Results</p>
+              <h3>Open full recap page</h3>
+              <p class="meta">View dual meets, tournaments, and season standings on their own screen.</p>
+              <button type="button" class="ghost" aria-label="Open results page">View Results</button>
             </div>
           </div>
           <div id="scout-report" class="log"></div>
@@ -213,27 +220,59 @@
         </section>
 
         <section class="card">
-          <h2>Weekly Summary</h2>
-          <ul id="weekly-summary" class="list"></ul>
-        </section>
-
-        <section class="card">
-          <h2>Standings</h2>
-          <ul id="standings-list" class="list"></ul>
-        </section>
-
-        <section class="card">
-          <h2>Postseason</h2>
-          <div id="postseason-log" class="log"></div>
-        </section>
-
-        <section class="card">
           <h2>Weekly Coaching Decisions</h2>
           <ul id="coaching-suggestions" class="list"></ul>
           <div class="field-row">
             <button id="rest-fatigue-btn" type="button">Rest High Fatigue</button>
             <button id="heal-minors-btn" type="button">Treat Minor Injuries</button>
           </div>
+        </section>
+      </section>
+
+      <section id="view-results" class="view">
+        <section class="card results-hero">
+          <div>
+            <p class="eyebrow">Competition Hub</p>
+            <h2>Dual & Tournament Results</h2>
+            <p class="meta">A dedicated page to review every dual meet, tournament bracket, and how your program stacks up.</p>
+          </div>
+          <div class="results-meta">
+            <div>
+              <span class="label">Season Day</span>
+              <span class="value" id="results-day">--</span>
+            </div>
+            <div>
+              <span class="label">Season Week</span>
+              <span class="value" id="results-week">--</span>
+            </div>
+            <div>
+              <span class="label">Record</span>
+              <span class="value" id="results-record">--</span>
+            </div>
+          </div>
+        </section>
+
+        <section class="card results-columns">
+          <div>
+            <h3>Results Ledger</h3>
+            <p class="meta">Completed duals and tournament rounds are archived here for a quick recap.</p>
+            <ul id="results-list" class="list results-stack"></ul>
+          </div>
+          <div class="results-side">
+            <div>
+              <h3>Weekly Summary</h3>
+              <ul id="weekly-summary" class="list"></ul>
+            </div>
+            <div>
+              <h3>Standings</h3>
+              <ul id="standings-list" class="list"></ul>
+            </div>
+          </div>
+        </section>
+
+        <section class="card">
+          <h3>Postseason & Tournament Highlights</h3>
+          <div id="postseason-log" class="log"></div>
         </section>
       </section>
 

--- a/src/core/dualMeet.ts
+++ b/src/core/dualMeet.ts
@@ -1,6 +1,7 @@
 // Dual meet simulation logic
 import { WEIGHT_CLASSES } from "../data/weights";
-import { simulateMatch, WinMethod, Wrestler } from "./match";
+import { simulateMatch } from "./match";
+import type { WinMethod, Wrestler } from "./match";
 
 export interface Team {
   name: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,13 @@
 // ---- Types ----
 
 import { simulateDual, teamPointsForMethod } from "./core/dualMeet";
-import { simulateMatch, WinMethod } from "./core/match";
+import { simulateMatch } from "./core/match";
+import type { WinMethod } from "./core/match";
 import { createId, pickRandom, randomDelta } from "./core/rng";
 import { WEIGHT_CLASSES } from "./data/weights";
 import { SCHOOL_NAMES } from "./schools";
-import { saveState, loadState, SavedState } from "./store/storage";
+import { saveState, loadState } from "./store/storage";
+import type { SavedState } from "./store/storage";
 import { logToElement } from "./ui/logger";
 import { buildLineupCard, ensureLineupSelections, renderRosterList } from "./ui/rosterUI";
 
@@ -1154,6 +1156,9 @@ const goalsList = document.getElementById("goals-list") as HTMLUListElement;
 const weeklySummaryList = document.getElementById("weekly-summary") as HTMLUListElement;
 const standingsList = document.getElementById("standings-list") as HTMLUListElement | null;
 const postseasonLogDiv = document.getElementById("postseason-log") as HTMLDivElement | null;
+const resultsDayEl = document.getElementById("results-day") as HTMLSpanElement | null;
+const resultsWeekEl = document.getElementById("results-week") as HTMLSpanElement | null;
+const resultsRecordEl = document.getElementById("results-record") as HTMLSpanElement | null;
 const restFatigueBtn = document.getElementById("rest-fatigue-btn") as HTMLButtonElement | null;
 const healMinorsBtn = document.getElementById("heal-minors-btn") as HTMLButtonElement | null;
 const strategySelect = document.getElementById("strategy-select") as HTMLSelectElement | null;
@@ -2056,6 +2061,9 @@ function updateSeasonUI() {
   if (seasonDaySpan) seasonDaySpan.textContent = dayLabel;
   if (seasonWeekSpan) seasonWeekSpan.textContent = String(seasonWeek);
   if (seasonRecordSpan) seasonRecordSpan.textContent = `${seasonWins}-${seasonLosses}`;
+  if (resultsDayEl) resultsDayEl.textContent = dayLabel;
+  if (resultsWeekEl) resultsWeekEl.textContent = String(seasonWeek);
+  if (resultsRecordEl) resultsRecordEl.textContent = `${seasonWins}-${seasonLosses}`;
   if (budgetSlider) budgetSlider.value = String(budget);
   if (nilSlider) nilSlider.value = String(nilBudget);
   if (homeDayLabel) {
@@ -2658,9 +2666,9 @@ navButtons.forEach((btn) => {
   });
 });
 
-document.querySelectorAll<HTMLButtonElement>(".tile-card").forEach((tile) => {
-  tile.addEventListener("click", () => {
-    const target = tile.dataset.target;
+document.querySelectorAll<HTMLElement>("[data-target]").forEach((el) => {
+  el.addEventListener("click", () => {
+    const target = (el as HTMLElement).dataset.target;
     if (!target) return;
     setActiveView(target);
   });

--- a/style.css
+++ b/style.css
@@ -194,6 +194,61 @@ button:hover {
   font-size: 18px;
 }
 
+.results-callout {
+  background: linear-gradient(135deg, rgba(34,197,94,0.12), rgba(14,165,233,0.08));
+  border: 1px solid #1f2937;
+  border-radius: 12px;
+  padding: 14px;
+  display: grid;
+  align-content: center;
+  gap: 6px;
+  cursor: pointer;
+}
+
+.results-callout button {
+  justify-self: start;
+}
+
+.results-hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  align-items: center;
+}
+
+.results-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  background: #111827;
+  border-radius: 12px;
+  padding: 12px;
+  border: 1px solid #1f2937;
+}
+
+.results-meta .value {
+  font-size: 20px;
+  font-weight: 700;
+  display: block;
+}
+
+.results-columns {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 16px;
+}
+
+.results-side {
+  display: grid;
+  gap: 12px;
+}
+
+.results-stack {
+  max-height: 420px;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
 .coach-menu-header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- add a dedicated Results navigation entry with a standalone competition hub
- move results, standings, and postseason logs into the new page with refreshed styling
- broaden view switching to any data-target element and update results metadata bindings

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c350a92088325be50a4bce5e71da3)