### PR TITLE
Add dedicated rankings view with sortable standings tables

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <nav class="nav">
       <button class="nav-btn active" data-view="home">Home</button>
       <button class="nav-btn" data-view="dashboard">Dashboard</button>
+      <button class="nav-btn" data-view="rankings">Rankings</button>
       <button class="nav-btn" data-view="training">Training</button>
       <button class="nav-btn" data-view="duals">Duals</button>
       <button class="nav-btn" data-view="results">Results</button>
@@ -55,7 +56,7 @@
             </div>
           </div>
           <div class="tile-grid">
-            <button class="tile-card" data-target="dashboard">
+            <button class="tile-card" data-target="rankings">
               <div class="tile-title">District Ranking</div>
               <div class="tile-body" id="tile-district-rank">--</div>
             </button>
@@ -67,7 +68,7 @@
               <div class="tile-title">School Profile</div>
               <div class="tile-body">Roster & prestige</div>
             </button>
-            <button class="tile-card" data-target="dashboard">
+            <button class="tile-card" data-target="rankings">
               <div class="tile-title">Regional Ranking</div>
               <div class="tile-body" id="tile-regional-rank">--</div>
             </button>
@@ -79,7 +80,7 @@
               <div class="tile-title">Coach's Profile</div>
               <div class="tile-body">Goals & prestige</div>
             </button>
-            <button class="tile-card" data-target="dashboard">
+            <button class="tile-card" data-target="rankings">
               <div class="tile-title">State Ranking</div>
               <div class="tile-body" id="tile-state-rank">--</div>
             </button>
@@ -143,6 +144,55 @@
         <div class="coach-bar-right">
           <button id="season-next-btn" type="button" class="primary">Next Day</button>
         </div>
+      </section>
+
+      <section id="view-rankings" class="view">
+        <section class="card">
+          <div class="coach-menu-header">
+            <div>
+              <p class="eyebrow">Rankings Center</p>
+              <h2>District, Regional, and State Standings</h2>
+              <p class="meta">Sort and page through standings using the same data that powers your season updates.</p>
+            </div>
+            <div class="field">
+              <label class="label" for="ranking-find-input">Find School</label>
+              <div class="input-row">
+                <input id="ranking-find-input" placeholder="Enter school name" />
+                <button id="ranking-find-btn" type="button" class="ghost">Search</button>
+              </div>
+              <p class="meta">Filters within the active tab and highlights matches.</p>
+            </div>
+          </div>
+
+          <div class="ranking-tabs" role="tablist" aria-label="Ranking scopes">
+            <button class="ranking-tab active" data-scope="district" role="tab" aria-selected="true">District</button>
+            <button class="ranking-tab" data-scope="regional" role="tab" aria-selected="false">Regional</button>
+            <button class="ranking-tab" data-scope="state" role="tab" aria-selected="false">State</button>
+          </div>
+
+          <div class="ranking-table-wrap">
+            <table id="ranking-table" class="ranking-table">
+              <thead>
+                <tr>
+                  <th data-sort="rank" scope="col">Rank</th>
+                  <th data-sort="name" scope="col">Team</th>
+                  <th data-sort="wins" scope="col">Wins</th>
+                  <th data-sort="ties" scope="col">Ties</th>
+                  <th data-sort="losses" scope="col">Losses</th>
+                  <th data-sort="rating" scope="col">Rating</th>
+                  <th data-sort="points" scope="col">Points</th>
+                </tr>
+              </thead>
+              <tbody id="ranking-table-body"></tbody>
+            </table>
+          </div>
+
+          <div class="ranking-pagination">
+            <button id="ranking-prev-btn" type="button" class="ghost">Previous</button>
+            <span id="ranking-page-info" class="meta">Page 1 of 1</span>
+            <button id="ranking-next-btn" type="button" class="ghost">Next</button>
+          </div>
+        </section>
       </section>
 
       <section id="view-dashboard" class="view active">

--- a/src/main.ts
+++ b/src/main.ts
@@ -189,6 +189,7 @@ interface LeagueTeam {
   id?: string;
   name: string;
   wins: number;
+  ties?: number;
   losses: number;
   pf: number;
   pa: number;
@@ -232,6 +233,18 @@ function renderWeeklySummaries(): void {
   if (homeTeamNameEl) homeTeamNameEl.textContent = teamName || "Your School";
 }
 
+function sortLeagueTeams(): LeagueTeam[] {
+  return [...league].sort((a, b) => {
+    const winPctA = a.wins + a.losses + (a.ties ?? 0) === 0 ? 0 : a.wins / (a.wins + a.losses + (a.ties ?? 0));
+    const winPctB = b.wins + b.losses + (b.ties ?? 0) === 0 ? 0 : b.wins / (b.wins + b.losses + (b.ties ?? 0));
+    if (winPctA !== winPctB) return winPctB - winPctA;
+    const diffA = a.pf - a.pa;
+    const diffB = b.pf - b.pa;
+    if (diffA !== diffB) return diffB - diffA;
+    return b.rating - a.rating;
+  });
+}
+
 function setActiveView(viewKey: string): void {
   for (const btn of navButtons) {
     btn.classList.toggle("active", btn.dataset.view === viewKey);
@@ -241,6 +254,7 @@ function setActiveView(viewKey: string): void {
   }
   if (viewKey === "home") refreshLatestSummary();
   if (viewKey === "results") renderTournamentIfAvailable();
+  if (viewKey === "rankings") renderRankingTable();
 }
 
 function ensureGazetteOverlay(): void {
@@ -504,26 +518,20 @@ function renderGazette(payload: GazettePayload): void {
   gazetteOverlay.classList.add("active");
 }
 function renderStandings(): void {
-  if (!standingsList) return;
-  standingsList.innerHTML = "";
-  if (league.length === 0) return;
-  const sorted = [...league].sort((a, b) => {
-    const winPctA = a.wins + a.losses === 0 ? 0 : a.wins / (a.wins + a.losses);
-    const winPctB = b.wins + b.losses === 0 ? 0 : b.wins / (b.wins + b.losses);
-    if (winPctA !== winPctB) return winPctB - winPctA;
-    const diffA = a.pf - a.pa;
-    const diffB = b.pf - b.pa;
-    if (diffA !== diffB) return diffB - diffA;
-    return b.rating - a.rating;
-  });
-  for (const team of sorted) {
-    const diff = team.pf - team.pa;
-    const winPct = team.wins + team.losses === 0 ? 0 : (team.wins / (team.wins + team.losses)) * 100;
-    const li = document.createElement("li");
-    if (team.name === teamName) li.classList.add("highlight");
-    const prestigeStr = team.prestige ? ` | Prestige ${team.prestige}` : "";
-    li.innerHTML = `<div><strong>${team.name}</strong> <span class="meta record">${team.wins}-${team.losses} (${winPct.toFixed(0)}%)</span></div><div class="meta">PF ${team.pf} | PA ${team.pa} | Diff ${diff} | Rating ${team.rating.toFixed(0)}${prestigeStr}${team.lastResult ? ` | ${team.lastResult}` : ""}</div>`;
-    standingsList.appendChild(li);
+  const sorted = sortLeagueTeams();
+  if (standingsList) {
+    standingsList.innerHTML = "";
+    for (const team of sorted) {
+      const diff = team.pf - team.pa;
+      const winPct = team.wins + team.losses + (team.ties ?? 0) === 0 ? 0 : (team.wins / (team.wins + team.losses + (team.ties ?? 0))) * 100;
+      const li = document.createElement("li");
+      if (team.name === teamName) li.classList.add("highlight");
+      const prestigeStr = team.prestige ? ` | Prestige ${team.prestige}` : "";
+      const ties = team.ties ?? 0;
+      const record = ties > 0 ? `${team.wins}-${ties}-${team.losses}` : `${team.wins}-${team.losses}`;
+      li.innerHTML = `<div><strong>${team.name}</strong> <span class="meta record">${record} (${winPct.toFixed(0)}%)</span></div><div class="meta">PF ${team.pf} | PA ${team.pa} | Diff ${diff} | Rating ${team.rating.toFixed(0)}${prestigeStr}${team.lastResult ? ` | ${team.lastResult}` : ""}</div>`;
+      standingsList.appendChild(li);
+    }
   }
 
   // Home tile rankings based on standings position
@@ -536,6 +544,101 @@ function renderStandings(): void {
   if (tileDistrict) tileDistrict.textContent = myRank ? ordinal(myRank) : "--";
   if (tileRegional) tileRegional.textContent = myRank ? ordinal(Math.max(1, myRank * 2)) : "--";
   if (tileState) tileState.textContent = myRank ? ordinal(Math.max(1, myRank * 4)) : "--";
+
+  renderRankingTable();
+}
+
+function getScopedStandings(scope: RankingScope): { team: LeagueTeam; rank: number; points: number; wins: number; ties: number; losses: number }[] {
+  const sorted = sortLeagueTeams();
+  return sorted.map((team, idx) => {
+    const baseRank = idx + 1;
+    const scopeRank = scope === "district" ? baseRank : scope === "regional" ? baseRank * 2 : baseRank * 4;
+    return {
+      team,
+      rank: scopeRank,
+      wins: team.wins,
+      ties: team.ties ?? 0,
+      losses: team.losses,
+      points: Math.max(0, team.pf),
+    };
+  });
+}
+
+function renderRankingTable(): void {
+  if (!rankingTableBody) return;
+  const rows = getScopedStandings(rankingScope);
+  const filtered = rankingFilter ? rows.filter((r) => r.team.name.toLowerCase().includes(rankingFilter.toLowerCase())) : rows;
+
+  const sorted = [...filtered].sort((a, b) => {
+    const direction = rankingSort.direction === "asc" ? 1 : -1;
+    if (rankingSort.key === "name") {
+      return a.team.name.localeCompare(b.team.name) * direction;
+    }
+    const valueFor = (r: (typeof rows)[number]) => {
+      switch (rankingSort.key) {
+        case "rank":
+          return r.rank;
+        case "wins":
+          return r.wins;
+        case "ties":
+          return r.ties;
+        case "losses":
+          return r.losses;
+        case "rating":
+          return r.team.rating;
+        case "points":
+          return r.points;
+        default:
+          return r.rank;
+      }
+    };
+    const valA = valueFor(a);
+    const valB = valueFor(b);
+    if (valA === valB) return a.rank - b.rank;
+    return (valA - valB) * direction;
+  });
+
+  const totalPages = Math.max(1, Math.ceil(sorted.length / RANKING_PAGE_SIZE));
+  if (rankingPage > totalPages) rankingPage = totalPages;
+  const startIdx = (rankingPage - 1) * RANKING_PAGE_SIZE;
+  const pageRows = sorted.slice(startIdx, startIdx + RANKING_PAGE_SIZE);
+
+  rankingTableBody.innerHTML = "";
+  if (pageRows.length === 0) {
+    const emptyRow = document.createElement("tr");
+    const emptyCell = document.createElement("td");
+    emptyCell.colSpan = 7;
+    emptyCell.textContent = rankingFilter ? "No schools match that search." : "No teams available yet.";
+    emptyRow.appendChild(emptyCell);
+    rankingTableBody.appendChild(emptyRow);
+  } else {
+    for (const row of pageRows) {
+      const tr = document.createElement("tr");
+      if (row.team.name === teamName) tr.classList.add("highlight");
+      if (rankingFilter && row.team.name.toLowerCase().includes(rankingFilter.toLowerCase())) tr.classList.add("search-match");
+      const record = row.ties > 0 ? `${row.wins}-${row.ties}-${row.losses}` : `${row.wins}-${row.losses}`;
+      tr.innerHTML = `
+        <td>${row.rank}</td>
+        <td>${row.team.name}</td>
+        <td>${row.wins}</td>
+        <td>${row.ties}</td>
+        <td>${row.losses}</td>
+        <td>${row.team.rating.toFixed(0)}</td>
+        <td>${row.points.toFixed(0)}<div class="meta">Record ${record}</div></td>
+      `;
+      rankingTableBody.appendChild(tr);
+    }
+  }
+
+  if (rankingPageInfo) rankingPageInfo.textContent = `Page ${rankingPage} of ${totalPages}`;
+  if (rankingPrevBtn) rankingPrevBtn.disabled = rankingPage <= 1;
+  if (rankingNextBtn) rankingNextBtn.disabled = rankingPage >= totalPages;
+
+  rankingHeaders.forEach((h) => {
+    const sortKey = h.dataset.sort as RankingSortKey | undefined;
+    h.classList.toggle("sorted", sortKey === rankingSort.key);
+    h.classList.toggle("desc", sortKey === rankingSort.key && rankingSort.direction === "desc");
+  });
 }
 
 
@@ -578,6 +681,13 @@ let liveDualState: LiveDualState | null = null;
 let lastTournamentBracket: TournamentBracket | null = null;
 let latestResultSummary = "";
 let offseasonRecap = "";
+type RankingScope = "district" | "regional" | "state";
+type RankingSortKey = "rank" | "name" | "wins" | "ties" | "losses" | "rating" | "points";
+let rankingScope: RankingScope = "district";
+let rankingSort: { key: RankingSortKey; direction: "asc" | "desc" } = { key: "rank", direction: "asc" };
+let rankingFilter = "";
+let rankingPage = 1;
+const RANKING_PAGE_SIZE = 10;
 const TRAINING_EFFECTS: Record<TrainingFocus, string> = {
   balanced: "+neutral/top/bottom/technique (small) | -fatigue",
   neutral: "+neutral/technique | -fatigue",
@@ -598,6 +708,7 @@ function initLeague(): void {
     id: p.id,
     name: p.name,
     wins: 0,
+    ties: 0,
     losses: 0,
     pf: 0,
     pa: 0,
@@ -1305,6 +1416,14 @@ const tileRegional = document.getElementById("tile-regional-rank") as HTMLDivEle
 const tileState = document.getElementById("tile-state-rank") as HTMLDivElement | null;
 const navButtons = Array.from(document.querySelectorAll<HTMLButtonElement>(".nav-btn"));
 const views = Array.from(document.querySelectorAll<HTMLElement>(".view"));
+const rankingTabButtons = Array.from(document.querySelectorAll<HTMLButtonElement>(".ranking-tab"));
+const rankingTableBody = document.querySelector("#ranking-table-body") as HTMLTableSectionElement | null;
+const rankingPrevBtn = document.getElementById("ranking-prev-btn") as HTMLButtonElement | null;
+const rankingNextBtn = document.getElementById("ranking-next-btn") as HTMLButtonElement | null;
+const rankingPageInfo = document.getElementById("ranking-page-info") as HTMLSpanElement | null;
+const rankingFindInput = document.getElementById("ranking-find-input") as HTMLInputElement | null;
+const rankingFindBtn = document.getElementById("ranking-find-btn") as HTMLButtonElement | null;
+const rankingHeaders = Array.from(document.querySelectorAll<HTMLTableCellElement>("#ranking-table thead th[data-sort]"));
 const latestResultEl = document.getElementById("latest-result") as HTMLParagraphElement | null;
 const nextOpponentEl = document.getElementById("next-opponent") as HTMLParagraphElement | null;
 const trainingEffectsEl = document.getElementById("training-effects") as HTMLParagraphElement | null;
@@ -3046,6 +3165,60 @@ navButtons.forEach((btn) => {
     if (!target) return;
     setActiveView(target);
     if (target === "results") renderTournamentIfAvailable();
+  });
+});
+
+rankingTabButtons.forEach((btn) => {
+  btn.addEventListener("click", () => {
+    const scope = btn.dataset.scope as RankingScope | undefined;
+    if (!scope) return;
+    rankingScope = scope;
+    rankingPage = 1;
+    rankingTabButtons.forEach((b) => {
+      const isActive = b.dataset.scope === scope;
+      b.classList.toggle("active", isActive);
+      b.setAttribute("aria-selected", `${isActive}`);
+    });
+    renderRankingTable();
+  });
+});
+
+const triggerRankingSearch = () => {
+  rankingFilter = (rankingFindInput?.value ?? "").trim();
+  rankingPage = 1;
+  renderRankingTable();
+};
+
+rankingFindBtn?.addEventListener("click", triggerRankingSearch);
+rankingFindInput?.addEventListener("keydown", (e) => {
+  if (e.key === "Enter") {
+    e.preventDefault();
+    triggerRankingSearch();
+  }
+});
+
+rankingPrevBtn?.addEventListener("click", () => {
+  if (rankingPage <= 1) return;
+  rankingPage -= 1;
+  renderRankingTable();
+});
+
+rankingNextBtn?.addEventListener("click", () => {
+  rankingPage += 1;
+  renderRankingTable();
+});
+
+rankingHeaders.forEach((header) => {
+  header.addEventListener("click", () => {
+    const sortKey = header.dataset.sort as RankingSortKey | undefined;
+    if (!sortKey) return;
+    if (rankingSort.key === sortKey) {
+      rankingSort = { key: sortKey, direction: rankingSort.direction === "asc" ? "desc" : "asc" };
+    } else {
+      rankingSort = { key: sortKey, direction: sortKey === "name" ? "asc" : "desc" };
+    }
+    rankingPage = 1;
+    renderRankingTable();
   });
 });
 

--- a/style.css
+++ b/style.css
@@ -158,6 +158,16 @@ button:hover {
   background: rgba(34, 197, 94, 0.08);
 }
 
+.input-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.input-row input {
+  flex: 1;
+}
+
 .field-row button {
   width: 100%;
 }
@@ -208,6 +218,85 @@ button:hover {
 
 .tile-body {
   font-size: 18px;
+}
+
+.ranking-tabs {
+  display: inline-flex;
+  gap: 8px;
+  padding: 8px;
+  background: #0f172a;
+  border: 1px solid #1f2937;
+  border-radius: 10px;
+  margin: 10px 0;
+}
+
+.ranking-tab {
+  border: 1px solid #1f2937;
+  background: #111827;
+  color: #e5e7eb;
+  border-radius: 8px;
+  padding: 10px 14px;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.ranking-tab.active {
+  background: #22c55e;
+  color: #022c22;
+  border-color: #22c55e;
+}
+
+.ranking-table-wrap {
+  overflow-x: auto;
+  margin-top: 10px;
+}
+
+.ranking-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.ranking-table th,
+.ranking-table td {
+  padding: 10px;
+  border-bottom: 1px solid #1f2937;
+  text-align: left;
+}
+
+.ranking-table th {
+  background: #0b1220;
+  cursor: pointer;
+  position: relative;
+  user-select: none;
+}
+
+.ranking-table th.sorted::after {
+  content: "▲";
+  position: absolute;
+  right: 10px;
+  font-size: 10px;
+  transform: translateY(-50%);
+  top: 50%;
+}
+
+.ranking-table th.sorted.desc::after {
+  content: "▼";
+}
+
+.ranking-table tr.highlight {
+  background: rgba(34, 197, 94, 0.08);
+}
+
+.ranking-table tr.search-match {
+  outline: 1px solid #22c55e;
+}
+
+.ranking-pagination {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 12px;
 }
 
 .results-callout {


### PR DESCRIPTION
## Summary
- add a dedicated rankings view with district, regional, and state tabs backed by existing standings data
- enable sorting, pagination, and find-school filtering to highlight teams in the active tab
- style the new standings table layout and wire nav/tile links to the rankings view

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cba2dfcb883259cc84ee47c380b8c)